### PR TITLE
Fixed accidental blocking of harmless resources from blacklisted websites

### DIFF
--- a/chrome/ext/background.js
+++ b/chrome/ext/background.js
@@ -127,6 +127,7 @@
   {
     // Capture parent frame here because onCommitted doesn't get this info.
     var frame = createFrame(details.tabId, details.frameId);
+    frame.url = new URL(details.url);
     frame.parent = framesOfTabs[details.tabId][details.parentFrameId] || null;
   });
 


### PR DESCRIPTION
Steps to reproduce the bug:
------------------------------
1. Open new tab
2. Navigate **quickly** to e.g. http://onfocus.io/
3. Try few more times if the css loaded.

Behaviour:
-----------------------
The first thing that is observed is that the CSS is blocked and the site looks bad.
e.g of requests that get blocked: http://onfocus.io/wp-content/themes/onfocus-mmxvi/style.css

Details:
--------------
The site mentioned above has this rule: `||onfocus.io^$third-party`.
The request gets blocked because when you open a new tab in chrome, the search engine is loaded (in my case google.com) so the request for CSS appears to be made from google due to the fact that onBeforeNavigate was first triggered with `url: google.com`

The reason why this happens only some times is that the `onCommitted` event (which is actually setting the `frame.url`) can happen after the decision to block the request.

There are many other domains that behave the same, onfocus.io was just an example.



<img width="1440" alt="screen shot 2016-12-11 at 8 22 59 pm" src="https://cloud.githubusercontent.com/assets/2988929/21082238/240a0396-bfe0-11e6-9b1f-f24b4e4c7c18.png">
