### PR TITLE
Fix infinite loop whitelisting

### DIFF
--- a/lib/whitelisting.js
+++ b/lib/whitelisting.js
@@ -73,7 +73,8 @@ exports.checkWhitelisted = (page, frame, originUrl,
       if (filter)
         return filter;
 
-      frame = parentFrame;
+      if (frame !== parentFrame)
+        frame = parentFrame;
     }
 
     return originUrl && match(page, originUrl, typeMask, null,


### PR DESCRIPTION
While developing the other extensions which works with HTTP request interception, I frequently encounter the case when whitelist check goes into the infinite loop. 

This small PR resolves this issue.