### PR TITLE
Expose basic adblock stats for other extensions

### DIFF
--- a/ext/background.js
+++ b/ext/background.js
@@ -607,4 +607,20 @@
       message, sender, sendResponse
     ).includes(true);
   });
+
+  /* External message passing */
+  browser.runtime.onMessageExternal.addListener(
+    // we could theoretically whitelist extension ids we agree
+    // to communicate with (if it's not additional overhead)
+    // e.g if (whitelistedExtensions.includes(sender.id)){ handle and respond }
+    (message, sender, sendResponse) =>
+    {
+      // for now handle only prefs and stats requests
+      if (message.type === "prefs.get" || message.type.test(/stats./))
+      {
+        ext.onMessage._dispatch(
+          message, sender, sendResponse
+        ).includes(true);
+      }
+    });
 }


### PR DESCRIPTION
Hi guys.

What about exposing some basic stats to external world (different extensions)?
I'd like to get `blocked_total` and utilize it in my other extension (of course assuming that AdBlock is installed too). Btw, extension is connected with internet privacy too.

Please note that this is very **rough PR** version and **more like POC** rather than complete code.
First I'd like to know your opinion, and if we are on the same page, please review and suggest some modifications if needed.
If you have any security concerns - we could theoretically restrict number of extensions that AdBlock allows to communicate to by whitelisting them (if it's not an additional overhead), but I believe that exposing some simple numbers won't jeopardize anything.

Thoughts?
Thanks.